### PR TITLE
Adding helm, jinja2 and GitHub CLI dependencies

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,13 @@ USER root
 RUN pip install \
   jupyterlab \
   bash_kernel \
+  jinja2 \
   ansible
+# Install helm
+RUN install -d /usr/local/bin/ /usr/local/src
+RUN curl -fsSL -o /usr/local/bin/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+RUN chmod 700 /usr/local/bin/get_helm.sh
+RUN env HELM_INSTALL_DIR=/usr/local/bin /usr/local/bin/get_helm.sh --no-sudo
 RUN python -m bash_kernel.install
 # Install IJava Kernel
 WORKDIR /usr/local/opt/ijava
@@ -19,7 +25,8 @@ RUN install -d /usr/local/opt/ijava \
   && python3 install.py --prefix /opt/app-root \
   && jupyter kernelspec install /opt/app-root/share/jupyter/kernels/java
 # Install java 17 and maven
-RUN dnf install -y java-17-openjdk-devel maven \
+RUN dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+RUN dnf install -y java-17-openjdk-devel maven jq gh \
   && alternatives --set java java-17-openjdk.x86_64 \
   && alternatives --set javac java-17-openjdk.x86_64
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Base image: [quay.io/opendatahub-contrib/workbench-images:vscode-datascience-c9s
 | java-17-openjdk-devel | We provide the full Java 17 OpenJDK SDK to run and compile Java applications cloned from git in the terminal and Java inline Jupyter Notebooks. |
 | maven | Maven is provided for compiling, installing, and deploying Java packages to Maven Central. |
 
+### Build the container with podman
+
+```bash
+podman build -t nerc-images/vscode-java:latest .
+```
+
+### Run the container with podman
+
+```bash
+podman run --rm -it --entrypoint /bin/bash nerc-images/vscode-java:latest
+```
+
 You can pull the latest [vscode-java container image](https://github.com/nerc-images/vscode-java/pkgs/container/vscode-java) below:
 
 ```


### PR DESCRIPTION
We will use these dependencies for development of the ai-telemetry project in NERC OpenShift AI. 