### PR TITLE
Chown user directory to allow image to run locally

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,4 +30,6 @@ RUN dnf install -y java-17-openjdk-devel maven jq gh \
   && alternatives --set java java-17-openjdk.x86_64 \
   && alternatives --set javac java-17-openjdk.x86_64
 
+RUN chown -R 1001 /opt/app-root/src
+
 USER 1001


### PR DESCRIPTION
This chowns `/opt/app-root/src` to the `default` user.

Before this change:

    # podman run -it --rm -p 8787:8787 -v testvol:/opt/app-root/src vscode-java
    [...]
    error parent:15 Uncaught exception: EACCES: permission denied, mkdir '/opt/app-root/src/.local/share/code-server'
    error parent:15 Error: EACCES: permission denied, mkdir '/opt/app-root/src/.local/share/code-server'
    info  Using user-data-dir ~/.local/share/code-server
    warn  Could not create socket at /opt/app-root/src/.local/share/code-server/code-server-ipc.sock
    error parent:15 Uncaught exception: EACCES: permission denied, mkdir '/opt/app-root/src/.local/share/code-server'
    error parent:15 Error: EACCES: permission denied, mkdir '/opt/app-root/src/.local/share/code-server'

After this change:

    # podman run -it --rm -p 8787:8787 -v testvol:/opt/app-root/src vscode-java
    (no permission errors)
