### PR TITLE
Avoid modifying WORKDIR

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,19 +11,22 @@ RUN pip install \
   bash_kernel \
   jinja2 \
   ansible
+
 # Install helm
 RUN install -d /usr/local/bin/ /usr/local/src
 RUN curl -fsSL -o /usr/local/bin/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 RUN chmod 700 /usr/local/bin/get_helm.sh
 RUN env HELM_INSTALL_DIR=/usr/local/bin /usr/local/bin/get_helm.sh --no-sudo
 RUN python -m bash_kernel.install
+
 # Install IJava Kernel
-WORKDIR /usr/local/opt/ijava
 RUN install -d /usr/local/opt/ijava \
+  && cd /usr/local/opt/ijava \
   && curl -L https://github.com/SpencerPark/IJava/releases/download/v$IJAVA_VERSION/ijava-$IJAVA_VERSION.zip -o /tmp/ijava-$IJAVA_VERSION.zip \
   && unzip -n /tmp/ijava-$IJAVA_VERSION.zip -d /usr/local/opt/ijava \
   && python3 install.py --prefix /opt/app-root \
   && jupyter kernelspec install /opt/app-root/share/jupyter/kernels/java
+
 # Install java 17 and maven
 RUN dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 RUN dnf install -y java-17-openjdk-devel maven jq gh \


### PR DESCRIPTION
The Containerfile modified `WORKDIR` during the `ijava` install, but did not restore the original value (`/opt/app-root/src`). This commit modifies the container build process so that we don't need to modify `WORKDIR`, preserving the original value.